### PR TITLE
Fix definition of FWHM

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -145,8 +145,7 @@ end
 
 function fwhm(filt::PhotometricFilter)
     Δ = diff(sign.(filt ./ maximum(filt) .- 0.5))
-    i1 = findfirst(!iszero, Δ)
-    i2 = findnext(!iszero, Δ, i1 + 1)
+    i1, i2 = findall(!iszero, Δ)[[begin, end]]
     return wave(filt)[i2] - wave(filt)[i1]
 end
 


### PR DESCRIPTION
As previously implemented, returns a FWHM of 40 angstrom for 2MASS J because it has oscillatory features around 11500 angstrom so that the filter curve crosses 50% transmission several times (see [here](http://svo2.cab.inta-csic.es/theory/fps/index.php?id=2MASS/2MASS.J&&mode=browse&gname=2MASS&gname2=2MASS#filter)). A better match to the values on SVO is obtained by comparing the first time the filter crosses 50% transmission to the last time it crosses 50% transmission. For filters that only cross these transitions once, there should be no difference in the result.