### PR TITLE
Remove `units` keyword argument to `read_filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pkg.add(url="https://github.com/JuliaAstro/PhotometricFilters.jl.git")
 
 ```julia
 using PhotometricFilters
-using PhotometricFilters: SDSS_u, SDSS_g, SDSS_r, SDSS_i, SDSS_z, fwhm
+using PhotometricFilters: SDSS_u, SDSS_g, SDSS_r, SDSS_i, SDSS_z, pivot_wavelength
 
 filts = [SDSS_u(), SDSS_g(), SDSS_r(), SDSS_i(), SDSS_z()]
 ```
@@ -45,10 +45,10 @@ Using [Unitful.jl](https://github.com/painterqubits/Unitful.jl) is built in to a
 
 ```julia
 
-julia> filt_units = SDSS_u(units=true);
+julia> filt = SDSS_u();
 
-julia> fwhm(filt_units)
-600.0 Å
+julia> pivot_wavelength(filt)
+3556.523969910118 Å
 ```
 
 ## Citations

--- a/src/library.jl
+++ b/src/library.jl
@@ -8,16 +8,14 @@ const PYPHOT_DATADEP = DataDep(
     "9078486ec989bc0ffddb60f9cda686dff887c5d69627bc4703fd41d78a9e7d46";
 )
 
-function read_filter(name::AbstractString, units=true)
+function read_filter(name::AbstractString)
     local wave, through, dtype, fname
     HDF5.h5open(datadep"filters/new_filters.hd5") do fh
         node = fh["filters/$name"]
         data = read(node)
         wave = map(i -> i.WAVELENGTH, data)
-        if units
-            unitstr = read(HDF5.attributes(node)["WAVELENGTH_UNIT"])
-            wave *= parse_unit(unitstr)
-        end
+        unitstr = read(HDF5.attributes(node)["WAVELENGTH_UNIT"])
+        wave *= parse_unit(unitstr)
         through = map(i -> i.THROUGHPUT, data)
         dtype = read(HDF5.attributes(node)["DETECTOR"])
         fname = read(HDF5.attributes(node)["NAME"])
@@ -313,5 +311,5 @@ const FILTER_NAMES = [
 
 for filter_name in FILTER_NAMES
     F = Symbol(filter_name)
-    @eval $F(; units=true) = read_filter($filter_name, units)
+    @eval $F() = read_filter($filter_name)
 end


### PR DESCRIPTION
Also removed the `units` keyword argument from library filter reading functions like `PhotometricFilters.2MASS_J()`. We are now always putting units in the filters so having this as an option doesn't really make sense.