### PR TITLE
Split magnitude function implementation

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -571,8 +571,20 @@ true
 """
 function magnitude(f::AbstractFilter, T::MagnitudeSystem, wavelengths, flux)
     fbar = ustrip(u"erg/s/cm^2/angstrom", mean_flux_density(f, wavelengths, F_lambda.(flux, Ref(f))))
-    return -25//10 * log10(fbar) - zeropoint_mag(f, T)
+    return magnitude(fbar, zeropoint_mag(f, T))
 end
+"""
+    magnitude(fbar, zeropoint)
+Calculates a magnitude from a mean flux density `fbar` (a plain number, in units of erg / s / cm^2 / Angstrom; see [`mean_flux_density`](@ref)) and a magnitude zeropoint `zeropoint` (see [`zeropoint_mag`](@ref)).
+
+```jldoctest
+julia> using PhotometricFilters: magnitude
+
+julia> magnitude(1e-10, 22.0) == -2.5 * log10(1e-10) - 22.0
+true
+```
+"""
+magnitude(fbar, zeropoint) = -25//10 * log10(fbar) - zeropoint
 
 ############################################################
 # Definition and methods for PhotometricFilter concrete type


### PR DESCRIPTION
Useful to have access to `magnitude(fbar, zeropoint)` for performance-sensitive applications where you want to reuse the same `zeropoint` but use different `fbar`. The current implementation forces you to recalculate `zeropoint_mag(f::AbstractFilter, T::MagnitudeSystem)` every time you call `magnitude`, which can add up when using the `Vega` magnitude system which requires a numerical integration.