### PR TITLE
Fix SVO API url, use `quiet = true` to suppress VOTables.jl warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 Manifest.toml
 /docs/build/
+/.claude/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhotometricFilters"
 uuid = "482c37c2-cde1-4201-a412-83b81535d120"
 authors = ["Miles Lucas <mdlucas@hawaii.edu> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/svo.jl
+++ b/src/svo.jl
@@ -6,7 +6,7 @@ import OrderedCollections: OrderedDict
 using XML: Node, LazyNode, children, simple_value, value, attributes, tag, next
 import VOTables
 
-const svo_url = "http://svo2.cab.inta-csic.es/theory/fps/fps.php"
+const svo_url = "https://svo2.cab.inta-csic.es/svo/theory/fps3/fps.php"
 const detector_types = (Energy(), Photon()) # SVO returns 0 or 1 for energy or photon
 const TYPE_VO_TO_JL = VOTables.TYPE_VO_TO_JL
 
@@ -149,7 +149,7 @@ function get_filter(filtername::AbstractString, magsys::Symbol=:Vega)
     end
 
     # Construct PhotometricFilter
-    table = VOTables.read(IOBuffer(file); unitful=true)
+    table = VOTables.read(IOBuffer(file); unitful=true, quiet=true)
     result = PhotometricFilter(table.Wavelength,
                                parse_throughput(d, table);
                                detector=detector_types[parse(Int, d["DetectorType"]) + 1],
@@ -384,7 +384,7 @@ function query_filters(; kwargs...)
     response = HTTP.get(svo_url; query = query)
 
     err_str = try
-        table = VOTables.read(IOBuffer(response.body))
+        table = VOTables.read(IOBuffer(response.body); quiet=true)
         df = DataFrame(table)
 
         # Add units to fields like ZeroPoint


### PR DESCRIPTION
VOTables.jl currently emits warnings because SVO sends empty unit strings unit="" on attributes without units, but unless `quiet = true` VOTables.jl will throw errors on non-numeric entries with unit attributes -- sent PR to address this.